### PR TITLE
v0.1.3

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -23,4 +23,7 @@ jobs:
     - name: Test with pytest
       run: |
         poetry run pytest -v
+    - name: Test coverage with pytest-cov
+      run: |
+        poetry run pytest --cov=mtf2json tests/
 

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,0 +1,26 @@
+name: mtf2json build and tests
+on: [push, pull_request]
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install poetry flake8
+        poetry install --sync
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --statistics
+    - name: Test with pytest
+      run: |
+        poetry run pytest -v
+

--- a/mtf2json/cli.py
+++ b/mtf2json/cli.py
@@ -112,10 +112,10 @@ def main() -> None:
     #  nr. of arguments for --mtf-file and --json-file must match
     if args.json_file and len(args.mtf_file) != len(args.json_file):
         print("\nError: The number of JSON files must match the number of MTF files.")
-    parser.print_help()
-    sys.exit(1)
+        parser.print_help()
+        sys.exit(1)
     # set convert to True if --json-file or --json-dir are specified (or multiple MTF files)
-    if args.json_file or args.json_dir or len(args.json_file) > 1:
+    if args.json_file or args.json_dir or (args.mtf_file and len(args.mtf_file) > 1):
         args.convert = True
 
     # convert given MTF file(s)

--- a/mtf2json/cli.py
+++ b/mtf2json/cli.py
@@ -54,7 +54,12 @@ def convert_dir(mtf_dir: Path,
         for file in files:
             if file.endswith('.mtf'):
                 mtf_path = Path(root) / file
-                json_path = (json_dir or mtf_path.parent) / mtf_path.with_suffix('.json').name
+                if json_dir:
+                    relative_path = mtf_path.relative_to(mtf_dir)
+                    json_path = json_dir / relative_path.with_suffix('.json')
+                    json_path.parent.mkdir(parents=True, exist_ok=True)
+                else:
+                    json_path = mtf_path.with_suffix('.json')
                 try:
                     data = read_mtf(mtf_path)
                     write_json(data, json_path)

--- a/mtf2json/cli.py
+++ b/mtf2json/cli.py
@@ -119,28 +119,29 @@ def main() -> None:
         args.convert = True
 
     # convert given MTF file(s)
-    for i, mtf_file in enumerate(args.mtf_file):
-        path = Path(mtf_file)
-        if not path.exists():
-            print(f"File {path} does not exist!")
-            sys.exit(1)
-        try:
-            data = read_mtf(path)
-        except ConversionError as e:
-            print(f"Failed to convert '{path}': {e}")
-            sys.exit(1)
-
-        # convert to JSON and print or write to file
-        if args.convert:
-            json_path = Path(args.json_file[i]) if args.json_file else path.with_suffix('.json')
-            try:
-                write_json(data, json_path)
-                print(f"Successfully saved JSON file '{json_path}'.")
-            except Exception as e:
-                print(f"Error: writing '{json_path}' failed with '{e}'")
+    if args.mtf_file:
+        for i, mtf_file in enumerate(args.mtf_file):
+            path = Path(mtf_file)
+            if not path.exists():
+                print(f"File {path} does not exist!")
                 sys.exit(1)
-        else:
-            print(json.dumps(data))
+            try:
+                data = read_mtf(path)
+            except ConversionError as e:
+                print(f"Failed to convert '{path}': {e}")
+                sys.exit(1)
+
+            # convert to JSON and print or write to file
+            if args.convert:
+                json_path = Path(args.json_file[i]) if args.json_file else path.with_suffix('.json')
+                try:
+                    write_json(data, json_path)
+                    print(f"Successfully saved JSON file '{json_path}'.")
+                except Exception as e:
+                    print(f"Error: writing '{json_path}' failed with '{e}'")
+                    sys.exit(1)
+            else:
+                print(json.dumps(data))
 
     # convert all MTF files in given directory
     if args.mtf_dir:

--- a/mtf2json/cli.py
+++ b/mtf2json/cli.py
@@ -28,13 +28,27 @@ def create_parser() -> argparse.ArgumentParser:
     parser.add_argument('--version', '-V',
                         action='store_true',
                         help="Print version")
+    parser.add_argument('--mtf-dir', '-M',
+                        type=str,
+                        help="Convert all MTF files in the given directory.",
+                        metavar="MTF_DIR")
+    parser.add_argument('--json-dir', '-J',
+                        type=str,
+                        help="Store all JSON files in the given directory.",
+                        metavar="JSON_DIR")
+    parser.add_argument('--recursive', '-r',
+                        action='store_true',
+                        help="Recursively convert MTF files in subdirectories.")
+    parser.add_argument('--ignore-errors', '-i',
+                        action='store_true',
+                        help="Continue converting files even if an error occurs.")
     return parser
 
 
 def convert_dir(mtf_dir: Path,
                 json_dir: Optional[Path] = None,
                 recursive: bool = True,
-                ignore_errors: bool = False) -> None:
+                ignore_errors: bool = False) -> int:
     """
     Convert all MTF files in the `mtf_dir` folder to JSON (and subfolders if `recursive` is True).
     The JSON files have the same name but suffix '.json' instead of '.mtf'.
@@ -50,6 +64,7 @@ def convert_dir(mtf_dir: Path,
         elif not json_dir.is_dir():
             raise ValueError(f"'{json_dir}' is not a directory.")
 
+    error_occured = False
     for root, _, files in os.walk(mtf_dir):
         for file in files:
             if file.endswith('.mtf'):
@@ -61,16 +76,18 @@ def convert_dir(mtf_dir: Path,
                 else:
                     json_path = mtf_path.with_suffix('.json')
                 try:
+                    print(f"'{mtf_path}' -> '{json_path}' ...  ", end='')
                     data = read_mtf(mtf_path)
                     write_json(data, json_path)
-                    print(f"Successfully converted '{mtf_path}' to '{json_path}'.")
+                    print("SUCCESS")
                 except ConversionError as e:
-                    if ignore_errors:
-                        print(f"Failed to convert '{mtf_path}': {e}")
-                    else:
-                        raise e
+                    error_occured = True
+                    print(f"ERROR: {e}")
+                    if not ignore_errors:
+                        return 1
         if not recursive:
             break
+    return 1 if error_occured else 0
 
 
 def main() -> None:
@@ -82,18 +99,26 @@ def main() -> None:
         print(f"{version} (MM: {mm_version})")
         sys.exit(0)
 
-    # check params
-    if not args.mtf_file or (args.json_file and len(args.mtf_file) != len(args.json_file)):
-        if args.json_file and len(args.mtf_file) != len(args.json_file):
-            print("\nError: The number of JSON files must match the number of MTF files.")
+    # either file conversion or directory conversion is allowed, but not both simultaneously
+    if (args.mtf_file and args.mtf_dir) or (args.json_file and args.json_dir):
+        print("\nError: Specify either --mtf-file or --mtf-dir, and either --json-file or --json-dir, but not both.")
         parser.print_help()
         sys.exit(1)
-
-    # set convert to True if json_file is specified
-    if args.json_file:
+    # either --mtf-file or --mtf-dir is required
+    if not args.mtf_file and not args.mtf_dir:
+        print("\nError: Either --mtf-file or --mtf-dir must be specified.")
+        parser.print_help()
+        sys.exit(1)
+    #  nr. of arguments for --mtf-file and --json-file must match
+    if args.json_file and len(args.mtf_file) != len(args.json_file):
+        print("\nError: The number of JSON files must match the number of MTF files.")
+    parser.print_help()
+    sys.exit(1)
+    # set convert to True if --json-file or --json-dir are specified (or multiple MTF files)
+    if args.json_file or args.json_dir or len(args.json_file) > 1:
         args.convert = True
 
-    # read MTF
+    # convert given MTF file(s)
     for i, mtf_file in enumerate(args.mtf_file):
         path = Path(mtf_file)
         if not path.exists():
@@ -116,6 +141,12 @@ def main() -> None:
                 sys.exit(1)
         else:
             print(json.dumps(data))
+
+    # convert all MTF files in given directory
+    if args.mtf_dir:
+        mtf_dir = Path(args.mtf_dir)
+        json_dir = Path(args.json_dir) if args.json_dir else None
+        sys.exit(convert_dir(mtf_dir, json_dir, args.recursive, args.ignore_errors))
 
 
 if __name__ == "__main__":

--- a/mtf2json/mtf2json.py
+++ b/mtf2json/mtf2json.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Dict, Any, Tuple, Union, Optional, List, cast, TextIO
 
 
-version = "0.1.2"
+version = "0.1.3"
 mm_version = "0.49.19.1"
 
 

--- a/mtf2json/mtf2json.pyi
+++ b/mtf2json/mtf2json.pyi
@@ -2,5 +2,13 @@ from pathlib import Path
 from typing import Dict, Any
 
 
+version: str
+mm_version: str
+
+
+class ConversionError(Exception):
+    ...
+
+
 def read_mtf(path: Path) -> Dict[str, Any]: ...
 def write_json(data: Dict[str, Any], path: Path) -> None: ...

--- a/poetry.lock
+++ b/poetry.lock
@@ -12,6 +12,73 @@ files = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.6.0"
+description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "coverage-7.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:dff044f661f59dace805eedb4a7404c573b6ff0cdba4a524141bc63d7be5c7fd"},
+    {file = "coverage-7.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a8659fd33ee9e6ca03950cfdcdf271d645cf681609153f218826dd9805ab585c"},
+    {file = "coverage-7.6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7792f0ab20df8071d669d929c75c97fecfa6bcab82c10ee4adb91c7a54055463"},
+    {file = "coverage-7.6.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d4b3cd1ca7cd73d229487fa5caca9e4bc1f0bca96526b922d61053ea751fe791"},
+    {file = "coverage-7.6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7e128f85c0b419907d1f38e616c4f1e9f1d1b37a7949f44df9a73d5da5cd53c"},
+    {file = "coverage-7.6.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a94925102c89247530ae1dab7dc02c690942566f22e189cbd53579b0693c0783"},
+    {file = "coverage-7.6.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:dcd070b5b585b50e6617e8972f3fbbee786afca71b1936ac06257f7e178f00f6"},
+    {file = "coverage-7.6.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d50a252b23b9b4dfeefc1f663c568a221092cbaded20a05a11665d0dbec9b8fb"},
+    {file = "coverage-7.6.0-cp310-cp310-win32.whl", hash = "sha256:0e7b27d04131c46e6894f23a4ae186a6a2207209a05df5b6ad4caee6d54a222c"},
+    {file = "coverage-7.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:54dece71673b3187c86226c3ca793c5f891f9fc3d8aa183f2e3653da18566169"},
+    {file = "coverage-7.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c7b525ab52ce18c57ae232ba6f7010297a87ced82a2383b1afd238849c1ff933"},
+    {file = "coverage-7.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bea27c4269234e06f621f3fac3925f56ff34bc14521484b8f66a580aacc2e7d"},
+    {file = "coverage-7.6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed8d1d1821ba5fc88d4a4f45387b65de52382fa3ef1f0115a4f7a20cdfab0e94"},
+    {file = "coverage-7.6.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01c322ef2bbe15057bc4bf132b525b7e3f7206f071799eb8aa6ad1940bcf5fb1"},
+    {file = "coverage-7.6.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03cafe82c1b32b770a29fd6de923625ccac3185a54a5e66606da26d105f37dac"},
+    {file = "coverage-7.6.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0d1b923fc4a40c5832be4f35a5dab0e5ff89cddf83bb4174499e02ea089daf57"},
+    {file = "coverage-7.6.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4b03741e70fb811d1a9a1d75355cf391f274ed85847f4b78e35459899f57af4d"},
+    {file = "coverage-7.6.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a73d18625f6a8a1cbb11eadc1d03929f9510f4131879288e3f7922097a429f63"},
+    {file = "coverage-7.6.0-cp311-cp311-win32.whl", hash = "sha256:65fa405b837060db569a61ec368b74688f429b32fa47a8929a7a2f9b47183713"},
+    {file = "coverage-7.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:6379688fb4cfa921ae349c76eb1a9ab26b65f32b03d46bb0eed841fd4cb6afb1"},
+    {file = "coverage-7.6.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f7db0b6ae1f96ae41afe626095149ecd1b212b424626175a6633c2999eaad45b"},
+    {file = "coverage-7.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bbdf9a72403110a3bdae77948b8011f644571311c2fb35ee15f0f10a8fc082e8"},
+    {file = "coverage-7.6.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc44bf0315268e253bf563f3560e6c004efe38f76db03a1558274a6e04bf5d5"},
+    {file = "coverage-7.6.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:da8549d17489cd52f85a9829d0e1d91059359b3c54a26f28bec2c5d369524807"},
+    {file = "coverage-7.6.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0086cd4fc71b7d485ac93ca4239c8f75732c2ae3ba83f6be1c9be59d9e2c6382"},
+    {file = "coverage-7.6.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1fad32ee9b27350687035cb5fdf9145bc9cf0a094a9577d43e909948ebcfa27b"},
+    {file = "coverage-7.6.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:044a0985a4f25b335882b0966625270a8d9db3d3409ddc49a4eb00b0ef5e8cee"},
+    {file = "coverage-7.6.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:76d5f82213aa78098b9b964ea89de4617e70e0d43e97900c2778a50856dac605"},
+    {file = "coverage-7.6.0-cp312-cp312-win32.whl", hash = "sha256:3c59105f8d58ce500f348c5b56163a4113a440dad6daa2294b5052a10db866da"},
+    {file = "coverage-7.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:ca5d79cfdae420a1d52bf177de4bc2289c321d6c961ae321503b2ca59c17ae67"},
+    {file = "coverage-7.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d39bd10f0ae453554798b125d2f39884290c480f56e8a02ba7a6ed552005243b"},
+    {file = "coverage-7.6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:beb08e8508e53a568811016e59f3234d29c2583f6b6e28572f0954a6b4f7e03d"},
+    {file = "coverage-7.6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2e16f4cd2bc4d88ba30ca2d3bbf2f21f00f382cf4e1ce3b1ddc96c634bc48ca"},
+    {file = "coverage-7.6.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6616d1c9bf1e3faea78711ee42a8b972367d82ceae233ec0ac61cc7fec09fa6b"},
+    {file = "coverage-7.6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad4567d6c334c46046d1c4c20024de2a1c3abc626817ae21ae3da600f5779b44"},
+    {file = "coverage-7.6.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:d17c6a415d68cfe1091d3296ba5749d3d8696e42c37fca5d4860c5bf7b729f03"},
+    {file = "coverage-7.6.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:9146579352d7b5f6412735d0f203bbd8d00113a680b66565e205bc605ef81bc6"},
+    {file = "coverage-7.6.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:cdab02a0a941af190df8782aafc591ef3ad08824f97850b015c8c6a8b3877b0b"},
+    {file = "coverage-7.6.0-cp38-cp38-win32.whl", hash = "sha256:df423f351b162a702c053d5dddc0fc0ef9a9e27ea3f449781ace5f906b664428"},
+    {file = "coverage-7.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:f2501d60d7497fd55e391f423f965bbe9e650e9ffc3c627d5f0ac516026000b8"},
+    {file = "coverage-7.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7221f9ac9dad9492cecab6f676b3eaf9185141539d5c9689d13fd6b0d7de840c"},
+    {file = "coverage-7.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ddaaa91bfc4477d2871442bbf30a125e8fe6b05da8a0015507bfbf4718228ab2"},
+    {file = "coverage-7.6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4cbe651f3904e28f3a55d6f371203049034b4ddbce65a54527a3f189ca3b390"},
+    {file = "coverage-7.6.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:831b476d79408ab6ccfadaaf199906c833f02fdb32c9ab907b1d4aa0713cfa3b"},
+    {file = "coverage-7.6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46c3d091059ad0b9c59d1034de74a7f36dcfa7f6d3bde782c49deb42438f2450"},
+    {file = "coverage-7.6.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4d5fae0a22dc86259dee66f2cc6c1d3e490c4a1214d7daa2a93d07491c5c04b6"},
+    {file = "coverage-7.6.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:07ed352205574aad067482e53dd606926afebcb5590653121063fbf4e2175166"},
+    {file = "coverage-7.6.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:49c76cdfa13015c4560702574bad67f0e15ca5a2872c6a125f6327ead2b731dd"},
+    {file = "coverage-7.6.0-cp39-cp39-win32.whl", hash = "sha256:482855914928c8175735a2a59c8dc5806cf7d8f032e4820d52e845d1f731dca2"},
+    {file = "coverage-7.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:543ef9179bc55edfd895154a51792b01c017c87af0ebaae092720152e19e42ca"},
+    {file = "coverage-7.6.0-pp38.pp39.pp310-none-any.whl", hash = "sha256:6fe885135c8a479d3e37a7aae61cbd3a0fb2deccb4dda3c25f92a49189f766d6"},
+    {file = "coverage-7.6.0.tar.gz", hash = "sha256:289cc803fa1dc901f84701ac10c9ee873619320f2f9aff38794db4a4a0268d51"},
+]
+
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.2.1"
 description = "Backport of PEP 654 (exception groups)"
@@ -85,6 +152,24 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-cov"
+version = "5.0.0"
+description = "Pytest plugin for measuring coverage."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"},
+    {file = "pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652"},
+]
+
+[package.dependencies]
+coverage = {version = ">=5.2.1", extras = ["toml"]}
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -98,4 +183,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7ebb5dd8faea4436166822c835d81638d22020d7c511977e705b1a9828cbf1b7"
+content-hash = "003b7a8bf9b6631ec6eeb72ad5c63bfa2c2981c85fd02bb10b585d95e4eda93a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ python = "^3.10"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.2.2"
+pytest-cov = "^5.0.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mtf2json"
-version = "0.1.2"
+version = "0.1.3"
 description = "Convert the MegaMek MTF format to JSON."
 authors = ["juk0de <juk0de@kadidlo.de>"]
 license = "MIT"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,74 @@
+import subprocess
+import tempfile
+import json
+from pathlib import Path
+
+
+def test_convert_to_stdout() -> None:
+    """
+    Executes `mtf2json --mtf-file <FILE>` and checks if the output is valid JSON.
+    """
+    mtf_file = Path("tests/mtf/biped/Amarok_3.mtf")
+    result = subprocess.run(
+        ["poetry", "run", "mtf2json", "--mtf-file", str(mtf_file)],
+        capture_output=True,
+        text=True
+    )
+    assert result.returncode == 0, f"Process failed with return code {result.returncode}"
+    try:
+        json_data = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        assert False, f"Output is not valid JSON: {e}"
+    assert isinstance(json_data, dict), "Output JSON is not a dictionary"
+
+
+def test_convert() -> None:
+    """
+    Executes `mtf2json --mtf-file <FILE> --convert` and checks if:
+    - a JSON file with the same name but suffix `.json` is created
+    - the JSON file contains valid json
+    """
+    mtf_file = Path("tests/mtf/biped/Banshee_BNC-3E.mtf")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        temp_mtf_file = Path(tmpdir) / mtf_file.name
+        temp_json_file = temp_mtf_file.with_suffix('.json')
+        temp_mtf_file.write_text(mtf_file.read_text())
+
+        result = subprocess.run(
+            ["poetry", "run", "mtf2json", "--mtf-file", str(temp_mtf_file), "--convert"],
+            capture_output=True,
+            text=True
+        )
+        assert result.returncode == 0, f"Process failed with return code {result.returncode}"
+        assert temp_json_file.exists(), f"JSON file {temp_json_file} was not created"
+        try:
+            with open(temp_json_file, 'r') as f:
+                json_data = json.load(f)
+        except json.JSONDecodeError as e:
+            assert False, f"Output file is not valid JSON: {e}"
+        assert isinstance(json_data, dict), "Output JSON is not a dictionary"
+
+
+def test_convert_to_specified_file() -> None:
+    """
+    Executes `mtf2json --mtf-file <FILE> --json-file <FILE>` and checks if
+    the JSON file contains valid JSON.
+    NOTE: `--convert` should be set automatically when `--json-file` is specified.
+    """
+    mtf_file = Path("tests/mtf/biped/Atlas_AS7-K.mtf")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        json_file = Path(tmpdir) / "Amarok_3.json"
+        result = subprocess.run(
+            ["poetry", "run", "mtf2json", "--mtf-file", str(mtf_file), "--json-file", str(json_file)],
+            capture_output=True,
+            text=True
+        )
+        print(result.stdout)
+        assert result.returncode == 0, f"Process failed with return code {result.returncode}"
+        assert json_file.exists(), f"JSON file {json_file} was not created"
+        try:
+            with open(json_file, 'r') as f:
+                json_data = json.load(f)
+        except json.JSONDecodeError as e:
+            assert False, f"Output file is not valid JSON: {e}"
+        assert isinstance(json_data, dict), "Output JSON is not a dictionary"


### PR DESCRIPTION
* implemented new CLI options `--mtf-dir` and `--json-dir`
  * can be used to convert all MTF files in a directory
* `--convert` is automatically enabled if:
  *  `--json-file` or `--json-dir` are specified
  * more than one argument has been passed with `--mtf-file`
* implemented CLI tests
  * see `test_cli.py`
* fixed the `mypy` stub for `mtf2json.py`
* configured Github actions
  * building, linting with `flake8`, testing with `pytest` and `pytest-cov`